### PR TITLE
Deserialize StatusMessage tag as content not attribute

### DIFF
--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -632,10 +632,7 @@ impl TryFrom<&StatusCode> for Event<'_> {
 }
 
 #[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub struct StatusMessage {
-    #[serde(rename = "@Value")]
-    pub value: Option<String>,
-}
+pub struct StatusMessage(Option<String>);
 
 impl StatusMessage {
     fn name() -> &'static str {
@@ -651,8 +648,8 @@ impl TryFrom<&StatusMessage> for Event<'_> {
         let mut writer = Writer::new(Cursor::new(&mut write_buf));
 
         writer.write_event(Event::Start(BytesStart::new(StatusMessage::name())))?;
-        if let Some(value) = &value.value {
-            writer.write_event(Event::Text(BytesText::from_escaped(value)))?;
+        if let Some(content) = &value.0 {
+            writer.write_event(Event::Text(BytesText::from_escaped(content)))?;
         }
         writer.write_event(Event::End(BytesEnd::new(StatusMessage::name())))?;
 

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -632,7 +632,7 @@ impl TryFrom<&StatusCode> for Event<'_> {
 }
 
 #[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub struct StatusMessage(Option<String>);
+pub struct StatusMessage(pub Option<String>);
 
 impl StatusMessage {
     fn name() -> &'static str {


### PR DESCRIPTION
Prior commit fixed serialization, but in testing, deserialization was found to still be broken, as the existing implementation expects to deserialize the message as an attribute, when it is actually represented as the content within the tag.

This ends up being a breaking change, but because it shouldn't deserialize anyways on 'correct' input, and serialization never worked before the prior commit, it should be considered relatively inconsequential. 